### PR TITLE
Reorder colors to fit standard terminal order

### DIFF
--- a/Dracula.colorscheme
+++ b/Dracula.colorscheme
@@ -8,13 +8,13 @@ Color=40,42,54
 Color=40,42,54
 
 [Color0]
-Color=189,147,249
+Color=40,42,54
 
 [Color0Faint]
-Color=189,147,249
+Color=40,42,54
 
 [Color0Intense]
-Color=189,147,249
+Color=40,42,54
 
 [Color1]
 Color=255,85,85
@@ -35,49 +35,49 @@ Color=80,250,123
 Color=80,250,123
 
 [Color3]
-Color=255,121,198
+Color=241,250,140
 
 [Color3Faint]
-Color=255,121,198
+Color=241,250,140
 
 [Color3Intense]
-Color=255,121,198
+Color=241,250,140
 
 [Color4]
-Color=139,233,253
+Color=98,114,164
 
 [Color4Faint]
-Color=139,233,253
+Color=98,114,164
 
 [Color4Intense]
-Color=139,233,253
+Color=98,114,164
 
 [Color5]
-Color=241,250,140
+Color=255,121,198
 
 [Color5Faint]
-Color=241,250,140
+Color=255,121,198
 
 [Color5Intense]
-Color=241,250,140
+Color=255,121,198
 
 [Color6]
-Color=98,114,164
+Color=139,233,253
 
 [Color6Faint]
-Color=98,114,164
+Color=139,233,253
 
 [Color6Intense]
-Color=98,114,164
+Color=139,233,253
 
 [Color7]
-Color=68,71,90
+Color=248,248,242
 
 [Color7Faint]
-Color=68,71,90
+Color=248,248,242
 
 [Color7Intense]
-Color=68,71,90
+Color=248,248,242
 
 [Foreground]
 Color=248,248,242
@@ -89,6 +89,7 @@ Color=248,248,242
 Color=248,248,242
 
 [General]
+Blur=false
 Description=Dracula
 Opacity=1
 Wallpaper=


### PR DESCRIPTION
> If you're fixing a UI issue, make sure you take two screenshots. One that shows the actual bug and another that shows how you fixed it.

I just reordered some colors:

Before:

![image](https://user-images.githubusercontent.com/10085143/62427944-0c3ece80-b6fb-11e9-84f6-7a600ddc1b89.png)

After:

![image](https://user-images.githubusercontent.com/10085143/62427948-1bbe1780-b6fb-11e9-9825-b1dc685ef160.png)
